### PR TITLE
adding flat encryption support to flat_deposit

### DIFF
--- a/docker/add-deposit-ui-to-flat/flat_deposit/Helpers/IngestService/Collection.php
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/Helpers/IngestService/Collection.php
@@ -189,4 +189,5 @@ class Collection extends SIP
 
 
     function customRollback($message){}
+    function generateFlatEncryptionMetadata() {}
 }

--- a/docker/add-deposit-ui-to-flat/flat_deposit/Helpers/IngestService/IngestFactory.php
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/Helpers/IngestService/IngestFactory.php
@@ -38,6 +38,7 @@ class IngestFactory
             $this->processLog['addResourcesToCmdi'] = $this->factorySIP->addResourcesToCmdi();
             //throw new IngestServiceException('Debug');
             $this->processLog['generatePolicy'] = $this->factorySIP->generatePolicy();
+            $this->processLog['generateFlatEncryptionMetadata'] = $this->factorySIP->generateFlatEncryptionMetadata();
             $this->processLog['createBag'] = $this->factorySIP->createBag();
             $this->processLog['doSword'] = $this->factorySIP->doSword();
             $this->processLog['doDoorkeeper'] = $this->factorySIP->doDoorkeeper();

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.info
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.info
@@ -1,0 +1,7 @@
+name = FLAT Auth
+package = FLAT
+description = FLAT Auth
+core = 7.x
+version = 7.x-0.1-dev
+dependencies[] = flat_deposit
+dependencies[] = authtoken

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.module
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.module
@@ -123,20 +123,24 @@ function flat_auth_check_token() {
 
         if (authtoken_authenticate($authtoken->token(), [$authtoken->type()])) {
 
-            return drupal_json_output([
+            echo drupal_json_output([
 
                 'type' => 'success',
                 'expiration_time' => (int)variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
                 'deletion_time' => (int)variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
             ]);
+
+            exit;
         }
     }
 
-    return drupal_json_output([
+    echo drupal_json_output([
 
         'type' => 'error',
         'message' => 'Invalid token2',
     ]);
+
+    exit;
 }
 
 function flat_auth_get_token() {
@@ -170,46 +174,40 @@ function flat_auth_renew_token() {
                 $token = flat_auth_get_token_for_user($user);
                 drupal_add_http_header('Authorization', 'Bearer ' . $token);
 
-                return drupal_json_output([
+                echo drupal_json_output([
 
                     'type' => 'success',
                     'expiration_time' => (int)variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
                     'deletion_time' => (int)variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
                 ]);
+
+                exit;
             }
         }
     }
 
-    return drupal_json_output([
+    echo drupal_json_output([
 
         'type' => 'error',
         'message' => 'Invalid token',
     ]);
+
+    exit;
 }
 
 function flat_auth_create_token() {
 
-    return drupal_json_output([
+    echo drupal_json_output([
         'token' => flat_auth_get_token(),
     ]);
+
+    exit;
 }
 
 function flat_auth_download_file($pid, $dsid) {
 
     flat_auth_serve($pid, $dsid, true);
     exit;
-    // require_once __DIR__ . '/vendor/autoload.php';
-
-    // $params['download'] = '1';
-
-    // return $this->getClient()
-    //             ->request('GET', '/tla-decryption/render/' . $pid . '/' . $dsid . '/' . $appToken, [
-    //               'query' => $params,
-    //               'version' => 1.0,
-    //               'read_timeout' => 6000,
-    //             ]);
-
-    // exit;
 }
 
 function flat_auth_stream_file($pid, $dsid) {
@@ -226,35 +224,6 @@ function flat_auth_serve($pid, $dsid, $download = false) {
     $url = $base_url . '/tla-decryption/render/' . $pid . '/' . $dsid . '/' . $appToken . '?download=' . ($download ? '1' : '0');
     header('Location: ' . $url);
     exit;
-    // $size = get_size($url);
-
-    // header('Accept-Ranges: bytes');
-    // header('Content-Disposition: attachment; filename="test.mp4"');
-    // header('Content-Length: '. $size);
-    // header('Content-Type: video/mp4');
-
-    // readfile($url);
-    // exit;
-}
-
-function get_size($url) {
-
-    $my_ch = curl_init();
-    curl_setopt($my_ch, CURLOPT_URL,$url);
-    curl_setopt($my_ch, CURLOPT_HEADER, true);
-    curl_setopt($my_ch, CURLOPT_NOBODY, true);
-    curl_setopt($my_ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($my_ch, CURLOPT_TIMEOUT, 10);
-    $r = curl_exec($my_ch);
-
-    foreach(explode("\n", $r) as $header) {
-
-        if(strpos($header, 'Content-Length:') === 0) {
-            return trim(substr($header,16));
-        }
-    }
-
-    return '';
 }
 
 /**

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.module
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/flat_auth.module
@@ -1,0 +1,280 @@
+<?php
+
+define('FLAT_AUTH_THRESHOLD_EXPIRE', 60 * 5);
+define('FLAT_AUTH_THRESHOLD_DELETE', 60 * 10);
+define('FLAT_AUTH_MAX_ERROR_COUNT', 10);
+define('FLAT_AUTH_MAX_USAGE_COUNT', 10);
+
+function flat_auth_menu() {
+
+  $items = [];
+  $items['flat_auth'] = [
+
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Flat Auth - Check Token',
+    'description' => 'Flat Auth - Check Token',
+    'page callback' => 'flat_auth_check_token',
+    'access callback' => true,
+  ];
+
+  $items['flat_auth/create'] = [
+
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Flat Auth - Create Token',
+    'description' => 'Flat Auth - Create Token',
+    'page callback' => 'flat_auth_create_token',
+    'access callback' => true,
+  ];
+
+  $items['flat_auth/renew'] = [
+
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Flat Auth - Renew Token',
+    'description' => 'Flat Auth - Renew Token',
+    'page callback' => 'flat_auth_renew_token',
+    'access callback' => true,
+  ];
+
+  $items['flat_auth/download'] = [
+
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Flat Auth - Download file',
+    'description' => 'Flat Auth - Downloading file test function',
+    'page callback' => 'flat_auth_download_file',
+    'access callback' => true,
+  ];
+
+  $items['flat_auth/stream'] = [
+
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Flat Auth - Stream file',
+    'description' => 'Flat Auth - Streaming file test function',
+    'page callback' => 'flat_auth_stream_file',
+    'access callback' => true,
+  ];
+
+  $items['admin/config/flat_deposit/flat_auth'] = [
+
+    'title' => 'FLAT Auth Configuration',
+    'description' => 'FLAT Auth Configuration',
+    'access arguments' => array('admin deposit module'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('flat_auth_admin_form'),
+    'file' => 'includes/admin.inc',
+    'weight' => 999,
+  ];
+
+  return $items;
+}
+
+function flat_auth_authtoken_type_info() {
+
+    return [
+
+        'flat_auth' => [
+
+            'entity type' => 'user',
+            'label' => 'FLAT Auth',
+            'settings' => [
+
+                'threshold expire' => variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
+                'threshold delete' => variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
+                'max error count'  => variable_get('flat_auth_max_error_count', FLAT_AUTH_MAX_ERROR_COUNT),
+                'max usage count'  => variable_get('flat_auth_max_usage_count', FLAT_AUTH_MAX_USAGE_COUNT),
+            ],
+            'generate token callback' => 'flat_auth_generate_token',
+        ],
+    ];
+}
+
+/**
+ * Generate an unique token
+ *
+ * @return string
+ */
+function flat_auth_generate_token() {
+    return drupal_strtoupper(bin2hex(drupal_random_bytes(16)));
+}
+
+/**
+ * Get the bearer token
+ */
+function flat_auth_get_bearer_token() {
+
+    $bearer_token = NULL;
+
+    if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+        $bearer_token = str_replace('Bearer ', '', $_SERVER['HTTP_AUTHORIZATION']);
+    } elseif (isset($_SERVER['HTTP_X_AUTHORIZATION'])) {
+        $bearer_token = str_replace('Bearer ', '', $_SERVER['HTTP_X_AUTHORIZATION']);
+    } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+        $bearer_token = str_replace('Bearer ', '', $_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+    }
+
+    return $bearer_token;
+}
+
+function flat_auth_check_token() {
+
+    $token = flat_auth_get_bearer_token();
+    $authtoken = authtoken_load($token);
+
+    if ($authtoken) {
+
+        if (authtoken_authenticate($authtoken->token(), [$authtoken->type()])) {
+
+            return drupal_json_output([
+
+                'type' => 'success',
+                'expiration_time' => (int)variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
+                'deletion_time' => (int)variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
+            ]);
+        }
+    }
+
+    return drupal_json_output([
+
+        'type' => 'error',
+        'message' => 'Invalid token2',
+    ]);
+}
+
+function flat_auth_get_token() {
+
+    global $user;
+    return flat_auth_get_token_for_user($user);
+}
+
+function flat_auth_get_token_for_user($user) {
+
+    $entity = $user;
+
+    $authtoken = authtoken_assign('flat_auth', $user, $entity);
+    return $authtoken->token();
+}
+
+function flat_auth_renew_token() {
+
+    $token = flat_auth_get_bearer_token();
+    $authtoken = authtoken_load($token);
+
+    if ($authtoken) {
+
+        if (authtoken_authenticate($authtoken->token(), [$authtoken->type()])) {
+
+            if ($user = user_load($authtoken->uid())) {
+
+                // renew in db
+                flat_auth_renew_token_db($authtoken);
+
+                $token = flat_auth_get_token_for_user($user);
+                drupal_add_http_header('Authorization', 'Bearer ' . $token);
+
+                return drupal_json_output([
+
+                    'type' => 'success',
+                    'expiration_time' => (int)variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
+                    'deletion_time' => (int)variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
+                ]);
+            }
+        }
+    }
+
+    return drupal_json_output([
+
+        'type' => 'error',
+        'message' => 'Invalid token',
+    ]);
+}
+
+function flat_auth_create_token() {
+
+    return drupal_json_output([
+        'token' => flat_auth_get_token(),
+    ]);
+}
+
+function flat_auth_download_file($pid, $dsid) {
+
+    flat_auth_serve($pid, $dsid, true);
+    exit;
+    // require_once __DIR__ . '/vendor/autoload.php';
+
+    // $params['download'] = '1';
+
+    // return $this->getClient()
+    //             ->request('GET', '/tla-decryption/render/' . $pid . '/' . $dsid . '/' . $appToken, [
+    //               'query' => $params,
+    //               'version' => 1.0,
+    //               'read_timeout' => 6000,
+    //             ]);
+
+    // exit;
+}
+
+function flat_auth_stream_file($pid, $dsid) {
+
+    flat_auth_serve($pid, $dsid, false);
+    exit;
+}
+
+function flat_auth_serve($pid, $dsid, $download = false) {
+
+    global $base_url;
+    $appToken = base64_encode($base_url . '/flat_auth|apptoken|' . flat_auth_get_token());
+
+    $url = $base_url . '/tla-decryption/render/' . $pid . '/' . $dsid . '/' . $appToken . '?download=' . ($download ? '1' : '0');
+    header('Location: ' . $url);
+    exit;
+    // $size = get_size($url);
+
+    // header('Accept-Ranges: bytes');
+    // header('Content-Disposition: attachment; filename="test.mp4"');
+    // header('Content-Length: '. $size);
+    // header('Content-Type: video/mp4');
+
+    // readfile($url);
+    // exit;
+}
+
+function get_size($url) {
+
+    $my_ch = curl_init();
+    curl_setopt($my_ch, CURLOPT_URL,$url);
+    curl_setopt($my_ch, CURLOPT_HEADER, true);
+    curl_setopt($my_ch, CURLOPT_NOBODY, true);
+    curl_setopt($my_ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($my_ch, CURLOPT_TIMEOUT, 10);
+    $r = curl_exec($my_ch);
+
+    foreach(explode("\n", $r) as $header) {
+
+        if(strpos($header, 'Content-Length:') === 0) {
+            return trim(substr($header,16));
+        }
+    }
+
+    return '';
+}
+
+/**
+ * renew auth token
+ *
+ * @param Authtoken $authtoken
+ *   The authentication token.
+ * @return bool
+ *   Whether the operation was successful.
+ */
+function flat_auth_renew_token_db(Authtoken $authtoken) {
+
+    $query = db_update('authtoken')
+      ->fields(array(
+        'updated' => REQUEST_TIME,
+      ))
+      ->expression('created', 'NOW()')
+      ->expression('updated', 'NOW()');
+
+    $query->condition('token', $authtoken->token());
+
+    return ($query->execute() > 0);
+  }

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/includes/admin.inc
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_auth/includes/admin.inc
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Flat Auth Admin Form
+ *
+ * @param array $form
+ * @param array $form_state
+ *
+ * @return array
+ */
+function flat_auth_admin_form($form, &$form_state) {
+
+    $form['general'] = [
+
+      '#type'   => 'fieldset',
+      '#title'  => t('Flat Auth'),
+      'expiration_time' => [
+
+          '#type'          => 'textfield',
+          '#title'         => t('Expiration time in seconds'),
+          '#default_value' => variable_get('flat_auth_expiration_time', FLAT_AUTH_THRESHOLD_EXPIRE),
+          '#description'     => 'How long should a token be valid for',
+      ],
+      'deletion_time' => [
+
+        '#type'          => 'textfield',
+        '#title'         => t('Deletion time in seconds'),
+        '#default_value' => variable_get('flat_auth_deletion_time', FLAT_AUTH_THRESHOLD_DELETE),
+        '#description'     => 'How long until a token will be marked for deletion',
+      ],
+      'max_error_count' => [
+
+        '#type'          => 'textfield',
+        '#title'         => t('Max error count until token is invalidated'),
+        '#default_value' => variable_get('flat_auth_max_error_count', FLAT_AUTH_MAX_ERROR_COUNT),
+        '#description'     => 'How many times errors can occur until token is invalidated',
+      ],
+      'max_usage_count' => [
+
+        '#type'          => 'textfield',
+        '#title'         => t('Max usage count'),
+        '#default_value' => variable_get('flat_auth_max_usage_count', FLAT_AUTH_MAX_USAGE_COUNT),
+        '#description'     => 'How many times can a token be used',
+      ],
+    ];
+
+    $form['actions'] = [
+
+        '#type'  => 'actions',
+        'submit' => [
+
+            '#type'   => 'submit',
+            '#value'  => t('Save Configuration'),
+            '#weight' => 0,
+            '#submit' => ['flat_auth_admin_form_submit'],
+        ],
+    ];
+
+    return $form;
+}
+
+/**
+ * Admin form submit handler
+ *
+ * @param array $form
+ * @param array $form_state
+ *
+ * @return void
+ */
+function flat_auth_admin_form_submit($form, &$form_state) {
+
+    if ($form_state['triggering_element']['#value'] === 'Save Configuration') {
+
+        variable_set('flat_auth_expiration_time', $form_state['values']['expiration_time']);
+        variable_set('flat_auth_deletion_time', $form_state['values']['deletion_time']);
+        variable_set('flat_auth_max_error_count', $form_state['values']['max_error_count']);
+        variable_set('flat_auth_max_usage_count', $form_state['values']['max_usage_count']);
+
+        drupal_set_message(t('Flat Auth Admin configuration was successfully saved'));
+    }
+}

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_deposit.install
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_deposit.install
@@ -913,3 +913,110 @@ function flat_deposit_update_7003() {
         db_create_table('flat_cmdi_templates', $schema['flat_cmdi_templates']);
     }
 }
+
+/**
+ * Adding encryption tagging
+ */
+function flat_deposit_update_7005() {
+
+    $fields = [];
+
+    $fields['flat_encrypted_resources'] = [
+        'field_name' => 'flat_encrypted_resources',
+        'type' => 'text',
+        'cardinality' => 1,
+        'settings' => [
+            'max_length' => 5000
+        ],
+    ];
+
+    foreach ($fields as $field) {
+        field_create_field($field);
+    }
+
+    $instances = [];
+
+    $instances['flat_encrypted_resources'] = [
+
+        'field_name' => 'flat_encrypted_resources',
+        'bundle' => 'flat_bundle',
+        'label' => 'Encrypted Resources',
+        'description' => 'Resources of bundle that need to be encrypted',
+        'widget' => [
+            'type' => 'text_textfield',
+        ],
+        'required' => false,
+        'settings' => [
+            'text_processing' => 0,
+        ],
+        'display' => [
+            'default' => [
+                'type' => 'hidden',
+                'label' => 'inline',
+            ],
+            'error' => [
+                'label' => 'inline',
+            ],
+        ],
+    ];
+
+    foreach ($instances as $instance) {
+
+        $instance['entity_type'] = 'node';
+        field_create_instance($instance);
+    }
+}
+
+
+/**
+ * Adding encryption auth endpoint
+ */
+function flat_deposit_update_7006() {
+
+    $fields = [];
+
+    $fields['flat_encrypted_auth_endpoint'] = [
+        'field_name' => 'flat_encrypted_auth_endpoint',
+        'type' => 'text',
+        'cardinality' => 1,
+        'settings' => [
+            'max_length' => 5000
+        ],
+    ];
+
+    foreach ($fields as $field) {
+        field_create_field($field);
+    }
+
+    $instances = [];
+
+    $instances['flat_encrypted_auth_endpoint'] = [
+
+        'field_name' => 'flat_encrypted_auth_endpoint',
+        'bundle' => 'flat_bundle',
+        'label' => 'Auth Url For Encrypted Resources Access',
+        'description' => 'Auth Url For Encrypted Resources Access',
+        'widget' => [
+            'type' => 'text_textfield',
+        ],
+        'required' => false,
+        'settings' => [
+            'text_processing' => 0,
+        ],
+        'display' => [
+            'default' => [
+                'type' => 'hidden',
+                'label' => 'inline',
+            ],
+            'error' => [
+                'label' => 'inline',
+            ],
+        ],
+    ];
+
+    foreach ($instances as $instance) {
+
+        $instance['entity_type'] = 'node';
+        field_create_instance($instance);
+    }
+}

--- a/docker/add-deposit-ui-to-flat/flat_deposit/flat_deposit.module
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/flat_deposit.module
@@ -835,6 +835,9 @@ function flat_deposit_theme()
         'flat_bundle_cmdi_resource_table' => array(
             'render element' => 'form',
         ),
+        'flat_bundle_manage_resources' => array(
+            'render element' => 'form',
+        ),
 
         'flat_modal' => [
             'template' => 'theme/flat-modal',
@@ -997,6 +1000,38 @@ function theme_flat_bundle_cmdi_resource_table($variables)
         $row[] = drupal_render($form[$index]['label']);
 
         $rows[] = $row;
+    }
+
+    // Return the themed table:
+    return theme('table', array('header' => $header, 'rows' => $rows));
+}
+
+/**
+ *
+ */
+function theme_flat_bundle_manage_resources($variables)
+{
+    // Note: $form will be $form['table_container'] from your
+    // form definition, as that is the element that #theme was
+    // applied to.
+    $form = $variables['form'];
+
+    // Define our $header and $rows variables
+    // $header = array(t('Resource ID'), t('File name'), t('Select'));.
+    $header = [
+        ['data' => t('Mark for encryption'), 'class' => 'resource-table-select'],
+        ['data' => t('File name'), 'class' => 'resource-table-filename'],
+    ];
+
+    $rows = [];
+
+    foreach (element_children($form) as $index) {
+
+        $rows[] = [
+
+            drupal_render($form[$index]['encrypt']),
+            drupal_render($form[$index]['filename']),
+        ];
     }
 
     // Return the themed table:
@@ -1209,6 +1244,8 @@ function flat_deposit_form_flat_bundle_node_form_alter(&$form, &$form_state, $fo
     hide($form['flat_original_path']);
     hide($form['flat_parent_title']);
     hide($form['flat_deleted_resources']);
+    hide($form['flat_encrypted_resources']);
+    hide($form['flat_encrypted_auth_endpoint']);
     hide($form['actions']['preview']);
 
     $form['flat_type']['und']['#disabled'] = true;
@@ -2190,38 +2227,19 @@ function flat_deposit_block_view($delta = '')
 
         case 'node_file_listing':
 
+            module_load_include('inc', 'flat_deposit', 'inc/flat_bundle.manage_resources_form');
+
             $node = menu_get_object();
             $node_wrapper = entity_metadata_wrapper('node', $node);
 
-            $location = $node_wrapper->flat_location->value();
             $orig_location = $node_wrapper->flat_original_path->value();
-
-            $dirname = basename($location);
             $orig_dirname = basename($orig_location);
-
-            $file_found = [];
-            if (file_exists($location)) {
-                // We ignore hidden files (starting with a dot). These will not be added to the bundle later on either.
-                $file_found = array_diff(preg_grep('/^([^.])/', scandir($location)), array('..', '.'));
-            }
-
-            if (empty($file_found)) {
-                $file_found[] = 'Folder does not contain any (accessible) files';
-            }
-
-            $rows = array();
-
-            foreach ($file_found as $value) {
-
-                $rows[] = array($value);
-            }
-
-            $content = theme('table', array('rows' => $rows));
 
             $block = array(
                 'subject' => t("Files in folder \"@dirname\" to be added to this bundle:", array('@dirname' => $orig_dirname)),
-                'content' => $content,
+                'content' => drupal_get_form('flat_bundle_manage_resources_form', ['node' => $node]),
             );
+
             break;
 
         case 'cmdi_resource_actions':

--- a/docker/add-deposit-ui-to-flat/flat_deposit/inc/flat_bundle.manage_resources_form.inc
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/inc/flat_bundle.manage_resources_form.inc
@@ -1,0 +1,89 @@
+<?php
+
+function flat_bundle_manage_resources_form($form, &$form_state) {
+
+    // hide blocks for function calls that are not related to nodes
+    $node = $form_state['build_info']['args'][0]['node'];
+
+    if (!$node){
+        return $form;
+    }
+
+    $node_wrapper = entity_metadata_wrapper('node', $node);
+
+    $form['flat_bundle_manage_resources'] = [
+
+        '#theme' => 'flat_bundle_manage_resources',
+        // Need to set #tree to be able to differentiate
+        // between the various delete buttons upon
+        // submission.
+        '#tree' => TRUE,
+    ];
+
+    $location = $node_wrapper->flat_location->value();
+
+    $files = [];
+    if (file_exists($location)) {
+
+        // We ignore hidden files (starting with a dot). These will not be added
+        // to the bundle later on either.
+        $files = array_diff(preg_grep('/^([^.])/', scandir($location)), ['..', '.']);
+    }
+
+    // normalizing currently saved metadata, null, empty str will be marked as empty array
+    $marked = $node_wrapper->flat_encrypted_resources->value();
+    $marked = empty($marked) ? [] : explode(',', $marked);
+
+    foreach ($files as $file) {
+
+        // using md5 on the filename to differentiate the resources
+        $id = md5($file);
+
+        $form['flat_bundle_manage_resources'][$id]['encrypt'] = [
+
+            '#type' => 'checkbox',
+            '#default_value' => in_array($id, $marked),
+        ];
+
+        $form['flat_bundle_manage_resources'][$id]['filename'] = [
+            '#markup' => t('!label', ['!label' => $file]),
+        ];
+    }
+
+    $form['buttons']['save'] = [
+
+        '#type' => 'submit',
+        '#value' => t('Save'),
+        '#submit' => ['flat_bundle_manage_resources_form_submit'],
+        '#attributes' => [
+            'class' => ['btn-success']
+        ]
+    ];
+
+    return $form;
+}
+
+function flat_bundle_manage_resources_form_submit($form, &$form_state) {
+
+    $node = menu_get_object();
+    $node_wrapper = entity_metadata_wrapper('node', $node);
+    $marked = [];
+
+    foreach ($form_state['values']['flat_bundle_manage_resources'] as $filenameMd5 => $fields) {
+
+        if (isset($fields['encrypt']) && $fields['encrypt'] === 1) {
+
+            // file has been marked as encrypted
+            $marked[] = $filenameMd5;
+        }
+    }
+
+    $node_wrapper->flat_encrypted_resources->set(implode(',', $marked));
+
+    $flat_auth_endpoint = url('flat_auth', ['absolute' => true]);
+    // var_dump($flat_auth_endpoint);exit;
+
+    $node_wrapper->flat_encrypted_auth_endpoint->set($flat_auth_endpoint);
+    $node_wrapper->save();
+    // var_dump($node_wrapper->flat_encrypted_auth_endpoint->value());exit;
+}

--- a/docker/add-deposit-ui-to-flat/flat_deposit/inc/flat_deposit.cmdi_form.inc
+++ b/docker/add-deposit-ui-to-flat/flat_deposit/inc/flat_deposit.cmdi_form.inc
@@ -467,6 +467,7 @@ function flat_deposit_cmdi_form_submit($form, &$form_state)
     // for some unknown reason flat_location and flat_original_path are messed up by attaching the newly created cmdi file, so we need to restore it
     $flat_location_original = $wrapper->flat_location->value();
     $flat_original_path_original = $wrapper->flat_original_path->value();
+    $flat_encrypted_auth_endpoint = $wrapper->flat_encrypted_auth_endpoint->value();
 
     $wrapper->flat_cmdi_file->file->set($new_file);
     $wrapper->save();
@@ -476,6 +477,7 @@ function flat_deposit_cmdi_form_submit($form, &$form_state)
 
     $wrapper->flat_location->set($flat_location_original);
     $wrapper->flat_original_path->set($flat_original_path_original);
+    $wrapper->flat_encrypted_auth_endpoint->set($flat_encrypted_auth_endpoint);
     $wrapper->save();
 
     drupal_set_message(t('Metadata for bundle %title has been saved', array('%title' => $node->title)));


### PR DESCRIPTION
- for doorkeeper, go to github.com/ibrahimab/doorkeeper (branch feature/encryption), run `mvn clean install -U` or just run the compose project and copy the jar from there
- for doorkeeper encryption action, go to github.com/thelanguagearchive/doorkeeperencryption (branch feature/flat_auth), run `mvn clean install -U` or just run the compose project and copy the jar from there
- for tla-encryption, go to github.com/thelanguagearchive/flat_encryption (branch feature/flat_auth) (this is the compose project), java folder and run `mvn clean install -U` or just run the compose project and copy the jar from there
- for flat_deposit, use the changes in this pull request
- run the compose project, and then run `docker compose exec vault sh /vault/scripts/register-plugin.sh <root-token>` to deploy the latest auth plugin into vault